### PR TITLE
fix: mapper for email templates link_parameters

### DIFF
--- a/src/iterable/resources/templates.py
+++ b/src/iterable/resources/templates.py
@@ -49,7 +49,7 @@ class Email(Resource):
         "from_name": "fromName",
         "google_analytics_campaign_name": "googleAnalyticsCampaignName",
         "html": "html",
-        "link_parameters": "linkParameters",
+        "link_parameters": "linkParams",
         "locale": "locale",
         "merge_data_feed_context": "mergeDataFeedContext",
         "message_type_id": "messageTypeId",


### PR DESCRIPTION
The link_parameters for email template in Iterable API is named `linkParams` not `linkParameters`.
Reference: https://api.iterable.com/api/docs#templates_upsertEmailTemplate