### PR TITLE
Add merge bool parameter to update email interface

### DIFF
--- a/src/iterable/resources/commerce.py
+++ b/src/iterable/resources/commerce.py
@@ -21,7 +21,7 @@ class Commerce(Resource):
         payload["campaignId"] = campaign_id
         payload["templateId"] = template_id
         payload["createdAt"] = created_at
-        payload["data_fields"] = data_fields
+        payload["dataFields"] = data_fields
         return self.client.post(resource, data=payload)
 
     def update_cart(self, user=None, items=None):

--- a/src/iterable/resources/users.py
+++ b/src/iterable/resources/users.py
@@ -128,11 +128,12 @@ class Users(Resource):
         payload["mergeNestedObjects"] = merge_nested_objects
         return self.client.post(resource, data=payload)
 
-    def update_email(self, current_email, new_email):
+    def update_email(self, current_email, new_email, merge=False):
         resource = "/api/users/updateEmail"
         payload = {}
         payload["currentEmail"] = str(current_email)
         payload["newEmail"] = str(new_email)
+        payload["merge"] = bool(merge)
         return self.client.post(resource, data=payload)
 
     def bulk_update(self, users):


### PR DESCRIPTION
New boolean parameter `merge` for the update email API interface 

It merges user accounts when the email is updated for a profile

This is a new iterable API feature that is currently supported 

Their public documentation has not been updated to reflect this so I can’t guarantee it will work for any individual Iterable Project without contacting your account representative. 

Here is a copy of the documentation I was given by our account representative:

https://dkpdw0r5j9hhy.cloudfront.net/Iterable/Merge+User+Profiles.pdf