### PR TITLE
Allow updating users with userId only

### DIFF
--- a/src/iterable/resources/users.py
+++ b/src/iterable/resources/users.py
@@ -122,9 +122,11 @@ class Users(Resource):
 
         resource = "/api/users/update"
         payload = {}
-        payload["email"] = str(email)
+        if email is not None:
+            payload["email"] = str(email)
         payload["dataFields"] = data_fields
-        payload["userId"] = str(user_id)
+        if user_id is not None:
+            payload["userId"] = str(user_id)
         payload["mergeNestedObjects"] = merge_nested_objects
         return self.client.post(resource, data=payload)
 


### PR DESCRIPTION
Iterable supports project where users have no email.

We need to be able to use the update endpoint with them.

Right now we get the following error:

```
iterable.exceptions.InvalidParameters: {'msg': 'Invalid email: none', 'code': 'InvalidEmailAddressError', 'params': None}
```
