### PR TITLE
Expect correct exception on client.py

### DIFF
--- a/src/iterable/client.py
+++ b/src/iterable/client.py
@@ -17,7 +17,7 @@ Exporting data is also supported, currently to a local file but the method could
 refactored to accept any file-like object (like a socket or a buffer)
 """
 import os
-from json import JSONDecodeError
+from requests.exceptions import JSONDecodeError
 import time
 from collections import namedtuple
 


### PR DESCRIPTION
Currently, the expected exception is json.JSONDecodeError, but the exception that requests.models.Response.json() raises for an invalid json is requests.JSONDecodeError. We need to catch the correct exception so we get the expected response object.